### PR TITLE
metadata-corrections-and-enhancements

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -16,7 +16,7 @@ description:
 
     - Reflexion und Resümee
 
-    - Epliog"
+    - Epilog"
 discipline:
   - übergreifend
 duration: 10h

--- a/metadata.yml
+++ b/metadata.yml
@@ -58,20 +58,20 @@ chapters:
       - learning-objective: Nach durcharbeiten der OER erkennen Sie die Technologie der QUADRIGA OERs, können diese in groben Zügen wiedergeben und können bei der Arbeit mit der OER auftretende Fehler den jeweiligen Komponenten zuordnen.
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
       - learning-objective: Nach durcharbeiten der OER können Sie selbst Inhalte in einer QUADRIGA OER anpassen und diese erweitern.
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 3 Apply
+        blooms-category: 3 Anwenden
       - learning-objective:
           de: Nach durcharbeiten der OER können Sie ausgehend von diesem OER-Template selbst vollkommen neue OERs im Stil der QUADRIGA OERs erstellen.
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 6 Create
+        blooms-category: 6 Erschaffen
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Präambel
     url: TODO
   - description: TODO
@@ -80,7 +80,7 @@ chapters:
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Struktur und didaktisches Konzept
     url: TODO
   - description: TODO
@@ -89,7 +89,7 @@ chapters:
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Technologie
     url: TODO
   - description: TODO
@@ -98,7 +98,7 @@ chapters:
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Formatierung
     url: TODO
   - description: TODO
@@ -107,7 +107,7 @@ chapters:
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Lernstandskontrolle (Assessment)
     url: TODO
   - description: TODO
@@ -116,7 +116,7 @@ chapters:
       - learning-objective: test
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category: 1 Remember
+        blooms-category:  1 Erinnern
     title: Reflexion und Resümee
     url: TODO
 context-of-creation:

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=quadriga-schema.json
-schema-version: 1.1-beta
+schema-version: 1.1-beta2
 oer-version: 0.51.0
-title: 'QUADRIGA OERs: erstellen und gestalten mit Jupyter Book. QUADRIGA Open Educational Resources: Template'
+title: "QUADRIGA OERs: erstellen und gestalten mit Jupyter Book. QUADRIGA Open Educational Resources: Template"
 description:
   introduction: Diese OER führt in die Erstellung von QUADRIGA-OERs ein, bietet Inhalte für Nutzer:innen der OERs und dient gleichzeitig als Template für die Erstellung eigener OERs auf Basis der QUADRIGA-Empfehlungen.
-  table-of-contents: '- Präambel
+  table-of-contents: "- Präambel
 
     - Struktur und didaktisches Konzept
 
@@ -16,12 +16,12 @@ description:
 
     - Reflexion und Resümee
 
-    - Epliog'
+    - Epliog"
 discipline:
-- übergreifend
+  - übergreifend
 duration: 10h
 type-of-research-object:
-- übergreifend
+  - übergreifend
 identifier: https://doi.org
 url: https://quadriga-dk.github.io/Book_Template/
 git: https://github.com/quadriga-dk/Book_Template
@@ -30,95 +30,96 @@ has-successor: false
 date-of-last-change: 2025-03-11
 publication-date: 2024-05-06
 target-group:
-- Forschende (PostDoc)
-- Forschende (Projektleitung)
-- Promovierende
-- Hochschullehrende
+  - Forschende (PostDoc)
+  - Forschende (Projektleitung)
+  - Promovierende
+  - Hochschullehrende
 authors:
-- given-names: Hannes
-  family-names: Schnaitter
-  orcid: https://orcid.org/0000-0002-1602-6032
-  affiliation: Humboldt-Universität zu Berlin, Institut für Bibliotheks- und Informationswissenschaft
-- given-names: Evgenia
-  family-names: Samoilova
-  orcid: https://orcid.org/0000-0003-3858-901X
-  affiliation: Universität Potsdam
-  credit:
-  - Writing
-- given-names: Lamia
-  family-names: Islam
-  affiliation: Universität Potsdam
-  credit:
-  - Software
+  - given-names: Hannes
+    family-names: Schnaitter
+    orcid: https://orcid.org/0000-0002-1602-6032
+    affiliation: Humboldt-Universität zu Berlin, Institut für Bibliotheks- und Informationswissenschaft
+  - given-names: Evgenia
+    family-names: Samoilova
+    orcid: https://orcid.org/0000-0003-3858-901X
+    affiliation: Universität Potsdam
+    credit:
+      - Writing
+  - given-names: Lamia
+    family-names: Islam
+    affiliation: Universität Potsdam
+    credit:
+      - Software
 chapters:
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Präambel
-  url: TODO
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Struktur und didaktisches Konzept
-  url: TODO
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Technologie
-  url: TODO
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Formatierung
-  url: TODO
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Lernstandskontrolle (Assessment)
-  url: TODO
-- description: TODO
-  doi: TODO
-  learning-objectives:
-  - learning-objective: test
-    competency: 1 Basiskompetenz
-    data-flow: Grundlagen
-    blooms-category: 1 Remember
-  title: Reflexion und Resümee
-  url: TODO
-learning-objectives:
-- learning-objective: Nach durcharbeiten der OER erkennen Sie die Technologie der QUADRIGA OERs, können diese in groben Zügen wiedergeben und können bei der Arbeit mit der OER auftretende Fehler den jeweiligen Komponenten zuordnen.
-  competency: 1 Basiskompetenz
-  data-flow: Grundlagen
-  blooms-category: 1 Remember
-- learning-objective: Nach durcharbeiten der OER können Sie selbst Inhalte in einer QUADRIGA OER anpassen und diese erweitern.
-  competency: 1 Basiskompetenz
-  data-flow: Grundlagen
-  blooms-category: 3 Apply
-- learning-objective:
-    de: Nach durcharbeiten der OER können Sie ausgehend von diesem OER-Template selbst vollkommen neue OERs im Stil der QUADRIGA OERs erstellen.
-  competency: 1 Basiskompetenz
-  data-flow: Grundlagen
-  blooms-category: 6 Create
-context-of-creation: 'Die vorliegenden Open Educational Resources wurden durch das Datenkompetenzzentrum QUADRIGA erstellt.
+  - description: TODO
+    learning-goal: TODO
+    duration: 1h
+    learning-objectives:
+      - learning-objective: Nach durcharbeiten der OER erkennen Sie die Technologie der QUADRIGA OERs, können diese in groben Zügen wiedergeben und können bei der Arbeit mit der OER auftretende Fehler den jeweiligen Komponenten zuordnen.
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+      - learning-objective: Nach durcharbeiten der OER können Sie selbst Inhalte in einer QUADRIGA OER anpassen und diese erweitern.
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 3 Apply
+      - learning-objective:
+          de: Nach durcharbeiten der OER können Sie ausgehend von diesem OER-Template selbst vollkommen neue OERs im Stil der QUADRIGA OERs erstellen.
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 6 Create
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Präambel
+    url: TODO
+  - description: TODO
+    learning-goal: TODO
+    learning-objectives:
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Struktur und didaktisches Konzept
+    url: TODO
+  - description: TODO
+    learning-goal: TODO
+    learning-objectives:
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Technologie
+    url: TODO
+  - description: TODO
+    learning-goal: TODO
+    learning-objectives:
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Formatierung
+    url: TODO
+  - description: TODO
+    learning-goal: TODO
+    learning-objectives:
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Lernstandskontrolle (Assessment)
+    url: TODO
+  - description: TODO
+    learning-goal: TODO
+    learning-objectives:
+      - learning-objective: test
+        competency: 1 Basiskompetenz
+        data-flow: Grundlagen
+        blooms-category: 1 Remember
+    title: Reflexion und Resümee
+    url: TODO
+context-of-creation:
+  "Die vorliegenden Open Educational Resources wurden durch das Datenkompetenzzentrum QUADRIGA erstellt.
 
-  Förderkennzeichen: 16DKZ1034'
+  Förderkennzeichen: 16DKZ1034"

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=quadriga-schema.json
 schema-version: 1.1-beta2
-oer-version: 0.51.0
+book-version: 0.51.0
 title: "QUADRIGA OERs: erstellen und gestalten mit Jupyter Book. QUADRIGA Open Educational Resources: Template"
 description:
   introduction: Diese OER führt in die Erstellung von QUADRIGA-OERs ein, bietet Inhalte für Nutzer:innen der OERs und dient gleichzeitig als Template für die Erstellung eigener OERs auf Basis der QUADRIGA-Empfehlungen.
@@ -25,8 +25,11 @@ type-of-research-object:
 identifier: https://doi.org
 url: https://quadriga-dk.github.io/Book_Template/
 git: https://github.com/quadriga-dk/Book_Template
-has-predecessor: false
-has-successor: false
+license:
+  code: https://opensource.org/licenses/AGPL-3.0
+  content: 
+    url: https://creativecommons.org/licenses/by-sa/4.0/
+    name: CC BY-SA 4.0
 date-of-last-change: 2025-03-11
 publication-date: 2024-05-06
 target-group:
@@ -58,20 +61,24 @@ chapters:
       - learning-objective: Nach durcharbeiten der OER erkennen Sie die Technologie der QUADRIGA OERs, können diese in groben Zügen wiedergeben und können bei der Arbeit mit der OER auftretende Fehler den jeweiligen Komponenten zuordnen.
         competency: 1 Basiskompetenz
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        focus: Wissen
+        blooms-category: 1 Erinnern
       - learning-objective: Nach durcharbeiten der OER können Sie selbst Inhalte in einer QUADRIGA OER anpassen und diese erweitern.
         competency: 1 Basiskompetenz
+        focus: Fähigkeit
         data-flow: Grundlagen
         blooms-category: 3 Anwenden
       - learning-objective:
           de: Nach durcharbeiten der OER können Sie ausgehend von diesem OER-Template selbst vollkommen neue OERs im Stil der QUADRIGA OERs erstellen.
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
         blooms-category: 6 Erschaffen
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Präambel
     url: TODO
   - description: TODO
@@ -79,8 +86,9 @@ chapters:
     learning-objectives:
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Struktur und didaktisches Konzept
     url: TODO
   - description: TODO
@@ -88,8 +96,9 @@ chapters:
     learning-objectives:
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Technologie
     url: TODO
   - description: TODO
@@ -97,8 +106,9 @@ chapters:
     learning-objectives:
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Formatierung
     url: TODO
   - description: TODO
@@ -106,8 +116,9 @@ chapters:
     learning-objectives:
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Lernstandskontrolle (Assessment)
     url: TODO
   - description: TODO
@@ -115,8 +126,9 @@ chapters:
     learning-objectives:
       - learning-objective: test
         competency: 1 Basiskompetenz
+        focus: Wissen
         data-flow: Grundlagen
-        blooms-category:  1 Erinnern
+        blooms-category: 1 Erinnern
     title: Reflexion und Resümee
     url: TODO
 context-of-creation:

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -275,7 +275,8 @@
             "description": "Versionsnummer des QUADRIGA-Metadatenschemas",
             "enum": [
                 "1.1",
-                "1.1-beta"
+                "1.1-beta",
+                "1.1-beta2"
             ]
         },
         "target-group": {

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -70,6 +70,12 @@
                         "format": "duration",
                         "@id": "schema:timeRequired"
                     },
+                    "duration": {
+                        "description": "Angedachte Bearbeitungsdauer für Lernende.",
+                        "type": "string",
+                        "format": "duration",
+                        "@id": "schema:timeRequired"
+                    },
                     "learning-objectives": {
                         "description": "Liste der Feinlernziele des Kapitels",
                         "$ref": "#/$defs/learning-objectives"
@@ -363,6 +369,14 @@
                             "13 Aufbereitung",
                             "14 Datenpublikation",
                             "15 Kommunikation"
+                        ]
+                    },
+                    "focus": {
+                        "description": "Fokus des Lernziels auf den Aspekt Wissen, Fähigkeit oder Haltung der Kompetenz.",
+                        "enum": [
+                            "Wissen",
+                            "Fähigkeit",
+                            "Haltung"
                         ]
                     },
                     "data-flow": {

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -16,10 +16,8 @@
         "description",
         "discipline",
         "duration",
-        "has-predecessor",
-        "has-successor",
         "identifier",
-        "oer-version",
+        "book-version",
         "publication-date",
         "schema-version",
         "target-group",
@@ -60,7 +58,7 @@
                         "$ref": "#/$defs/multilingual-text"
                     },
                     "url": {
-                        "description": "URL zum direkten Zugriff auf das Kapitel",
+                        "description": "URL zum direkten Zugriff auf die erste Seite der 'Leseansicht' (Website) des Kapitel.",
                         "type": "string",
                         "format": "uri"
                     },
@@ -77,6 +75,29 @@
                     "learning-goal": {
                         "$ref": "#/$defs/multilingual-text",
                         "description": "Kurze Benennung des Groblernziels des Kapitels."
+                    },
+                    "supplemented-by": {
+                        "description": "Liste von Verweisen und jeweils einer kurzen Beschreibung zu zusätzlichen, weiterführenden Inhalten o.ä.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "link",
+                                "description"
+                            ],
+                            "properties": {
+                                "description": {
+                                    "description": "Beschreibung des verlinkten Werks und dessen Beziehung zur OER.",
+                                    "$ref": "#/$defs/multilingual-text"
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "@id": "dct:relation"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
                     }
                 }
             }
@@ -170,13 +191,13 @@
             "@id": "dct:relation"
         },
         "identifier": {
-            "description": "Eindeutiger Identifier in Form einer DOI. Die DOI identifiziert die gesamte OER.",
+            "description": "Eindeutiger Identifier in Form einer DOI. Die DOI identifiziert das gesamte Buch.",
             "type": "string",
             "format": "uri",
             "@id": "dct:identifier"
         },
         "keywords": {
-            "description": "Liste von Schlag-/Stichwörtern",
+            "description": "Liste von Schlag-/Stichwörtern, welche das Buch und dessen (Lern-)Inhalte beschreiben.",
             "type": "array",
             "minItems": 1,
             "items": {
@@ -194,31 +215,113 @@
             }
         },
         "language": {
-            "description": "Sprache der OER als ISO639-1 Sprachcode",
+            "description": "Sprache der OER als ISO639-1 Sprachcode.",
             "type": "string",
             "@id": "dct:language"
         },
-        "learning-objectives": {
-            "description": "Groblernziele der OER",
-            "$ref": "#/$defs/learning-objectives"
-        },
         "license": {
-            "@id": "dct:license",
-            "description": "Lizenz der OER als URL",
-            "format": "uri",
-            "type": "string"
+            "description": "Lizenz des Buchs und des Codes jeweils als URL oder als Kombination aus Lizenznname und URL.",
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "description": "Lizenz des Buchs",
+                    "oneOf": [
+                        {
+                            "@id": "dct:license",
+                            "description": "URL zur Lizenz des Buchs",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        {
+                            "description": "Lizenzname und URL zur Lizenz des Buchs",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "@id": "dct:license",
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "url"
+                            ],
+                            "additionalProperties": false
+                        }
+                    ]
+                },
+                "code": {
+                    "description": "Lizenz des Codes",
+                    "oneOf": [
+                        {
+                            "@id": "dct:license",
+                            "description": "URL zur Lizenz des Codes",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        {
+                            "description": "Lizenzname und URL zur Lizenz des Codes",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "@id": "dct:license",
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "url"
+                            ],
+                            "additionalProperties": false
+                        }
+                    ]
+                }
+            }
         },
-        "oer-version": {
-            "description": "Version der OER",
+        "book-version": {
+            "description": "Version des Buchs.",
             "$ref": "#/$defs/semver"
         },
         "prerequesites": {
-            "description": "Liste von Voraussetzungen",
+            "description": "Liste von Voraussetzungen und deren jeweiliger Einordnung in der Bloomschen Taxonomie, welche Lernende für die erfolgreiche Bearbeitung des Buchs mitbringen sollten.",
             "type": "array",
             "minItems": 1,
+            "uniqueItems": true,
             "items": {
-                "description": "Eine Voraussetzung",
-                "$ref": "#/$defs/multilingual-text"
+                "description": "Eine Voraussetzung.",
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "$ref": "#/$defs/multilingual-text"
+                    },
+                    "blooms-category": {
+                        "description": "Kategorie der Bloomschen Taxonomie, der die Voraussetzung zugeordnet ist.",
+                        "enum": [
+                            "1 Erinnern",
+                            "2 Verstehen",
+                            "3 Anwenden",
+                            "4 Analysieren",
+                            "5 Bewerten",
+                            "6 Erschaffen"
+                        ]
+                    }
+                },
+                "required": [
+                    "description",
+                    "blooms-category"
+                ],
+                "additionalProperties": false
             }
         },
         "publication-date": {
@@ -323,7 +426,30 @@
             "format": "uri"
         },
         "used-tools": {
-            "$comment": "TODO"
+            "description": "Liste von Tools, die bei der Erstellung des Buchs verwendet wurden.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    {
+                        "description": "Strukturierte Angabe des Tools",
+                        "@id": "schema:softwareApplication",
+                        "properties": {
+                            "name": {
+                                "$ref": "#/$defs/multilingual-text"
+                            },
+                            "url": {
+                                "type": "string",
+                                "format": "uri"
+                            }
+                        }
+                    }
+                ]
+            }
         }
     },
     "additionalProperties": false,
@@ -338,15 +464,17 @@
                 "required": [
                     "learning-objective",
                     "competency",
-                    "data-flow"
+                    "data-flow",
+                    "focus",
+                    "blooms-category"
                 ],
                 "properties": {
                     "learning-objective": {
-                        "description": "Formulierung des Lernziels",
+                        "description": "Formulierung des Lernziels.",
                         "$ref": "#/$defs/multilingual-text"
                     },
                     "competency": {
-                        "description": "Im Lernziel adressierte Kompetenz nach dem QUADRIGA Datenkompetenzframework",
+                        "description": "Im Lernziel adressierte Kompetenz nach dem QUADRIGA Datenkompetenzframework.",
                         "enum": [
                             "1 Basiskompetenz",
                             "2 Identifikation",
@@ -366,7 +494,7 @@
                         ]
                     },
                     "focus": {
-                        "description": "Fokus des Lernziels auf den Aspekt Wissen, Fähigkeit oder Haltung der Kompetenz.",
+                        "description": "Fokus des Lernziels auf den Aspekt \"Wissen\", \"Fähigkeit\" oder \"Haltung\" der Kompetenz.",
                         "enum": [
                             "Wissen",
                             "Fähigkeit",
@@ -374,7 +502,7 @@
                         ]
                     },
                     "data-flow": {
-                        "description": "Im Lernziel adressierte Kompetenz nach dem QUADRIGA Datenkompetenzframework",
+                        "description": "Schritt im Datenfluss, dem die Kompetenz zugeordnet ist.",
                         "enum": [
                             "Grundlagen",
                             "Planung",
@@ -385,7 +513,7 @@
                         ]
                     },
                     "blooms-category": {
-                        "description": "Kategorie aus der Bloomschen Taxonomie.",
+                        "description": "Kategorie der Bloomschen Taxonomie, welcher das Lernziel zugeordnet ist. Aus der Kombination der Zuordnungen der Lernziele eines Kapitels lässt sich ein allgemeines Kompetenzniveau (\"Basis\", \"Fortgeschritten\", \"Expert:in\") ableiten.",
                         "enum": [
                             "1 Erinnern",
                             "2 Verstehen",
@@ -417,13 +545,15 @@
             ]
         },
         "person": {
+            "description": "Eine Person, die an der Erstellung der OER beteiligt war.",
+            "@id": "schema:person",
             "oneOf": [
                 {
                     "type": "string",
-                    "description": "Vollständiger Name der Person"
+                    "description": "Vollständiger Name der Person."
                 },
                 {
-                    "description": "Strukturierte Angabe der Person bestehend mindestens aus Vor- und Nachname",
+                    "description": "Strukturierte Angabe der Person bestehend mindestens aus Vor- und Nachname.",
                     "$comment": "Andere Schlüssel können nach Bedarf angelegt werden.",
                     "type": "object",
                     "required": [
@@ -432,12 +562,12 @@
                     ],
                     "properties": {
                         "given-names": {
-                            "description": "Vorname der Person",
+                            "description": "Vorname(n) der Person",
                             "type": "string",
                             "@id": "schema:givenName"
                         },
                         "family-names": {
-                            "description": "Nachname der Person",
+                            "description": "Nachname(n) der Person",
                             "type": "string",
                             "@id": "schema:familyName"
                         },
@@ -448,7 +578,7 @@
                             "pattern": "^https://orcid.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"
                         },
                         "credit": {
-                            "description": "Rolle der Person nach CRediT (siehe https://credit.niso.org",
+                            "description": "Rolle der Person nach CRediT (siehe https://credit.niso.org.",
                             "type": "array",
                             "items": {
                                 "enum": [

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -379,12 +379,12 @@
                     "blooms-category": {
                         "description": "Kategorie aus der Bloomschen Taxonomie.",
                         "enum": [
-                            "1 Remember",
-                            "2 Understand",
-                            "3 Apply",
-                            "4 Analyze",
-                            "5 Evaluate",
-                            "6 Create"
+                            "1 Erinnern",
+                            "2 Verstehen",
+                            "3 Anwenden",
+                            "4 Analysieren",
+                            "5 Bewerten",
+                            "6 Erschaffen"
                         ]
                     }
                 },

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -19,7 +19,6 @@
         "has-predecessor",
         "has-successor",
         "identifier",
-        "learning-objectives",
         "oer-version",
         "publication-date",
         "schema-version",
@@ -48,17 +47,13 @@
                 "required": [
                     "title",
                     "description",
-                    "learning-objectives"
+                    "learning-objectives",
+                    "learning-goal"
                 ],
                 "properties": {
                     "title": {
                         "description": "Kapitelüberschrift",
                         "$ref": "#/$defs/multilingual-text"
-                    },
-                    "doi": {
-                        "description": "DOI zum direkten Zitieren des Kapitels",
-                        "type": "string",
-                        "format": "uri"
                     },
                     "description": {
                         "description": "Beschreibung des Kapitelinhalts.",
@@ -69,9 +64,19 @@
                         "type": "string",
                         "format": "uri"
                     },
+                    "duration": {
+                        "description": "Angedachte Bearbeitungsdauer für Lernende.",
+                        "type": "string",
+                        "format": "duration",
+                        "@id": "schema:timeRequired"
+                    },
                     "learning-objectives": {
                         "description": "Liste der Feinlernziele des Kapitels",
                         "$ref": "#/$defs/learning-objectives"
+                    },
+                    "learning-goal": {
+                        "$ref": "#/$defs/multilingual-text",
+                        "description": "Kurze Benennung des Groblernziels des Kapitels."
                     }
                 }
             }

--- a/quadriga-schema.json
+++ b/quadriga-schema.json
@@ -70,12 +70,6 @@
                         "format": "duration",
                         "@id": "schema:timeRequired"
                     },
-                    "duration": {
-                        "description": "Angedachte Bearbeitungsdauer für Lernende.",
-                        "type": "string",
-                        "format": "duration",
-                        "@id": "schema:timeRequired"
-                    },
                     "learning-objectives": {
                         "description": "Liste der Feinlernziele des Kapitels",
                         "$ref": "#/$defs/learning-objectives"


### PR DESCRIPTION
Updates and enhancements to the metadata schema.

Notable changes:
- use german values for blooms taxonomy
- update `license` field
- remove global learning objectives and introduce `learning-goal` per chapter
- enhance `learning-objectives`
- clearer language differentiation between chapters (OERs) and the whole book
- formatting
- add `supplemented-by` to chapter descriptions
- enhance `prerequisites`
- `used-tools`