### PR TITLE
feat: add capability to update metadata on tag push

### DIFF
--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -20,21 +20,45 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Extract version from tag (if triggered by tag)
+        id: extract_version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            # Remove 'v' prefix if present (v1.0.0 -> 1.0.0)
+            VERSION=${TAG_NAME#v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "is_tag=true" >> $GITHUB_OUTPUT
+            echo "Triggered by version tag: $TAG_NAME (version: $VERSION)"
+          else
+            echo "is_tag=false" >> $GITHUB_OUTPUT
+            echo "Triggered by regular push to: $GITHUB_REF"
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version-file: '.python-version'
           cache: pip
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyyaml
-      
+
+      - name: Update version metadata (if triggered by tag)
+        if: steps.extract_version.outputs.is_tag == 'true'
+        env:
+          TAG_VERSION: ${{ steps.extract_version.outputs.version }}
+        run: |
+          python -m quadriga.metadata.update_version_from_tag
+
       - name: Update metadata files
         run: python -m quadriga.metadata.run_all
-      
+
       - name: Check if files changed
         id: check_changes
         run: |
@@ -43,12 +67,45 @@ jobs:
           else
             echo "changes_detected=true" >> $GITHUB_OUTPUT
           fi
-      
-      - name: Commit changes if necessary
-        if: steps.check_changes.outputs.changes_detected == 'true'
+
+      - name: Commit changes (regular push)
+        if: steps.check_changes.outputs.changes_detected == 'true' && steps.extract_version.outputs.is_tag == 'false'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add metadata.yml CITATION.bib
+          git add metadata.yml CITATION.bib CITATION.cff
           git commit -m "[Automated] Update metadata files"
           git push
+
+      - name: Commit changes and move tag (tag-triggered)
+        if: steps.check_changes.outputs.changes_detected == 'true' && steps.extract_version.outputs.is_tag == 'true'
+        run: |
+          # Configure git
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # Commit the metadata changes
+          git add metadata.yml CITATION.bib CITATION.cff
+          git commit -m "[Automated] Update metadata for version ${{ steps.extract_version.outputs.version }}"
+
+          # Delete the old tag (locally and remotely)
+          git tag -d ${{ steps.extract_version.outputs.tag_name }}
+          git push origin :refs/tags/${{ steps.extract_version.outputs.tag_name }}
+
+          # Create new tag at the current commit (with updated metadata)
+          git tag ${{ steps.extract_version.outputs.tag_name }}
+
+          # Push the changes and the new tag
+          git push origin HEAD:main
+          git push origin ${{ steps.extract_version.outputs.tag_name }}
+
+          echo "Tag ${{ steps.extract_version.outputs.tag_name }} moved to commit with updated metadata"
+
+      - name: No changes needed
+        if: steps.check_changes.outputs.changes_detected == 'false'
+        run: |
+          if [[ "${{ steps.extract_version.outputs.is_tag }}" == "true" ]]; then
+            echo "Metadata already matches the tag version - no changes needed"
+          else
+            echo "No metadata changes detected"
+          fi

--- a/quadriga/metadata/__init__.py
+++ b/quadriga/metadata/__init__.py
@@ -5,10 +5,17 @@ This subpackage contains scripts for managing metadata across different formats
 including CITATION.cff, CITATION.bib, and extracting metadata from _config.yml.
 """
 
-__all__ = ["create_bibtex", "update_citation_cff", "extract_from_book_config", "utils"]
+__all__ = [
+    "create_bibtex",
+    "update_citation_cff",
+    "extract_from_book_config",
+    "update_version_from_tag",
+    "utils",
+]
 
 # Import the modules to make their functions available
 from . import create_bibtex
 from . import update_citation_cff
 from . import extract_from_book_config
+from . import update_version_from_tag
 from . import utils

--- a/quadriga/metadata/update_version_from_tag.py
+++ b/quadriga/metadata/update_version_from_tag.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Updates book-version and date-of-last-change in metadata.yml based on git tag.
+"""
+import logging
+import sys
+import os
+from datetime import datetime
+from .utils import load_yaml_file, save_yaml_file, get_file_path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def update_version_from_tag():
+    """
+    Updates book-version and date-of-last-change in metadata.yml from git tag.
+
+    Expects the version to be passed via environment variable TAG_VERSION.
+
+    Returns:
+        bool: True if successful, False otherwise.
+    """
+    try:
+        # Get version from environment variable (set by GitHub Actions)
+        version = os.environ.get("TAG_VERSION")
+        if not version:
+            logging.info(
+                "No TAG_VERSION environment variable found - skipping version update"
+            )
+            return True
+
+        logging.info(f"Updating metadata for version: {version}")
+
+        # Get file path
+        try:
+            repo_root = get_file_path("")
+            metadata_path = get_file_path("metadata.yml", repo_root)
+        except Exception as e:
+            logging.error(f"Failed to resolve file paths: {str(e)}")
+            return False
+
+        # Load metadata.yml
+        metadata = load_yaml_file(metadata_path)
+        if not metadata:
+            logging.error("Could not load metadata.yml")
+            return False
+
+        # Track if updates were made
+        updates_made = False
+
+        # Update book-version
+        current_version = metadata.get("book-version")
+        if current_version != version:
+            metadata["book-version"] = version
+            updates_made = True
+            logging.info(
+                f"Updated book-version from '{current_version}' to '{version}'"
+            )
+        else:
+            logging.info(f"book-version already matches tag version: {version}")
+
+        # Update date-of-last-change
+        current_date = datetime.now().strftime("%Y-%m-%d")
+        old_date = metadata.get("date-of-last-change")
+        if old_date != current_date:
+            metadata["date-of-last-change"] = current_date
+            updates_made = True
+            logging.info(
+                f"Updated date-of-last-change from '{old_date}' to '{current_date}'"
+            )
+        else:
+            logging.info(f"date-of-last-change already current: {current_date}")
+
+        # Save if updates were made
+        if updates_made:
+            success = save_yaml_file(
+                metadata_path,
+                metadata,
+                schema_comment="# yaml-language-server: $schema=https://quadriga-dk.github.io/quadriga-schema/schema.json",
+            )
+            if success:
+                logging.info("Successfully updated metadata.yml")
+            return success
+        else:
+            logging.info("No updates needed")
+            return True
+
+    except Exception as e:
+        logging.exception(f"Unexpected error in update_version_from_tag: {str(e)}")
+        return False
+
+
+if __name__ == "__main__":
+    success = update_version_from_tag()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
`book-version` and `date-of-last-change` will be updated when a tag is pushed. The tag is then moved. This ensures correct metadata for releases.