### PR TITLE
feat: Switch thebe to use pyodide via the TeachBooks/Sphinx-Thebe plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,3 +71,8 @@ sphinx:
       - carousel.css
     html_js_files:
       - carousel.js
+      - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
+    thebe_config:
+      use_thebe_lite: true
+      exclude_patterns: ["**/_*.yml", "**/*.md", "**/*.ipynb"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 numpy
 sparqlkernel
 ipywidgets==8.1.7
+git+https://github.com/TeachBooks/Sphinx-Thebe
+


### PR DESCRIPTION
This changes the thebe live conding integration to use pyodide (in 
browser web assembly python interpreter) instead of mybinder.org.