### PR TITLE
feat(ci): add kernel setup matrix for Python and R

### DIFF
--- a/.github/workflows/deploy-book-python-sparql-r.yml
+++ b/.github/workflows/deploy-book-python-sparql-r.yml
@@ -11,8 +11,60 @@ on:
 # This job installs dependencies, builds the book, and deploys it to GitHub Pages
 # only runs if "Update Metadata" workflow is successful
 jobs:
+  setup-kernels:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        kernel: [python, r]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Python setup
+    - name: Set up Python
+      if: matrix.kernel == 'python'
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: '.python-version'
+        cache: pip
+
+    - name: Install Python dependencies
+      if: matrix.kernel == 'python'
+      run: |
+        pip install -r requirements.txt
+
+    - name: Install SPARQL kernel
+      if: matrix.kernel == 'python'
+      run: |
+        jupyter sparqlkernel install --user
+
+    # R setup
+    - name: Set up R
+      if: matrix.kernel == 'r'
+      uses: r-lib/actions/setup-r@v2
+
+    - name: Install R dependencies
+      if: matrix.kernel == 'r'
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        cache: true
+        cache-version: 2
+        packages: |
+          any::tidyverse
+          any::IRkernel
+        install-pandoc: false
+        install-quarto: false
+
+    - name: Set up IRkernel
+      if: matrix.kernel == 'r'
+      run: |
+        IRkernel::installspec(name="ir", displayname="R")
+      shell: Rscript {0}
+
   deploy-book:
     runs-on: ubuntu-latest
+    needs: setup-kernels
     permissions:
       pages: write
       id-token: write
@@ -21,7 +73,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Python
+    # Re-setup Python for build job
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -32,8 +84,7 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-
-    # R
+    # Re-setup R for build job
     - name: Set up R
       uses: r-lib/actions/setup-r@v2
 
@@ -53,12 +104,10 @@ jobs:
         IRkernel::installspec(name="ir", displayname="R")
       shell: Rscript {0}
 
-
-    # SPARQL
+    # Install SPARQL kernel
     - name: Install SPARQL kernel
       run: |
         jupyter sparqlkernel install --user
-
 
     # check all kernels 
     - name: Log all available kernels


### PR DESCRIPTION
Add a new setup-kernels job that runs on workflow success and sets up
both Python and R kernels in parallel via a matrix. For Python the job
installs dependencies and the SPARQL Jupyter kernel; for R it sets up
R, installs specified packages (tidyverse and IRkernel) and registers
IRkernel. Make the main deploy-book job depend on setup-kernels and
adjust comments to clarify re-setup steps for Python, R, and SPARQL
during the build job.

This ensures required kernels and dependencies are prepared before the
book build and deployment, reducing duplication and improving
reliability of the CI pipeline.