### PR TITLE
feat: Add usable `install_dependencies.R`

### DIFF
--- a/install_dependencies.R
+++ b/install_dependencies.R
@@ -1,2 +1,3 @@
-# packages <- c("tidyverse")
-# pak::pak(packages)
+install.packages("tidyverse", repo="https://ftp.gwdg.de/pub/misc/cran/")
+install.packages("IRkernel", repo="https://ftp.gwdg.de/pub/misc/cran/")
+IRkernel::installspec(name="ir", displayname="R")


### PR DESCRIPTION
Can be run via bash `$ R install_dependencies.R` and should set 
everything up correctly.